### PR TITLE
feat: add vercel config for backend

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.vercel

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ flake8-isort==6.1.2
 h11==0.16.0
 httpx==0.28.1
 idna==3.10
-psycopg2==2.9.10
+psycopg2-binary==2.9.10
 pydantic==2.11.4
 pydantic_core==2.33.2
 python-dotenv==1.1.0

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,0 +1,15 @@
+{
+  "devCommand": "uvicorn app.main:app --reload --host 0.0.0.0 --port 8000",
+  "builds": [
+    {
+      "src": "app/main.py",
+      "use": "@vercel/python"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "app/main.py" 
+    }
+  ]
+}


### PR DESCRIPTION
Closes #33 

Add vercel config for backend service.
See current deployment at https://eutop-mediamind-backend.vercel.app/api/docs.