### PR TITLE
Add ALB config to ECS module and ACM certificate support

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -60,17 +60,18 @@ module "s3" {
 }
 
 module "ecs" {
-  source            = "./modules/ecs"
-  service_name      = "mediamind-service"
-  cluster_name      = local.cluster_name
-  container_image   = module.ecr.repository_url
-  db_endpoint       = module.database.endpoint
-  redis_endpoint    = module.redis.endpoint
-  subnet_ids        = data.aws_subnets.selected.ids
-  vpc_id            = data.aws_vpc.selected.id
-  secrets_arn       = local.secrets_arn
-  s3_backend_bucket = module.s3.bucket
-  region            = "eu-central-1"
+  source              = "./modules/ecs"
+  service_name        = "mediamind-service"
+  cluster_name        = local.cluster_name
+  container_image     = module.ecr.repository_url
+  db_endpoint         = module.database.endpoint
+  redis_endpoint      = module.redis.endpoint
+  subnet_ids          = data.aws_subnets.selected.ids
+  vpc_id              = data.aws_vpc.selected.id
+  secrets_arn         = local.secrets_arn
+  s3_backend_bucket   = module.s3.bucket
+  region              = "eu-central-1"
+  acm_certificate_arn = "arn:aws:acm:eu-central-1:313193269185:certificate/ba1c0b9b-2c80-4c0f-acf6-355dfb9ba658"
 }
 
 module "qdrant" {

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -8,6 +8,7 @@ variable "vpc_id" { type = string }
 variable "secrets_arn" { type = string }
 variable "s3_backend_bucket" { type = string }
 variable "region" { type = string }
+variable "acm_certificate_arn" { type = string }
 variable "log_group_name" {
   type    = string
   default = null
@@ -21,32 +22,84 @@ resource "aws_cloudwatch_log_group" "ecs" {
   retention_in_days = 7
 }
 
-resource "aws_lb" "ecs_nlb" {
-  name               = "${var.service_name}-nlb"
+resource "aws_security_group" "ecs_service" {
+  name_prefix = "${var.service_name}-sg-"
+  description = "Allow inbound traffic to ECS service from ALB"
+  vpc_id      = var.vpc_id
+  lifecycle {
+    create_before_destroy = true
+  }
+  ingress {
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb" "ecs_alb" {
+  name               = "${var.service_name}-alb"
   internal           = false
-  load_balancer_type = "network"
+  load_balancer_type = "application"
   subnets            = var.subnet_ids
+  security_groups    = [aws_security_group.ecs_service.id]
 }
 
 resource "aws_lb_target_group" "ecs" {
   name        = "${var.service_name}-tg"
   port        = 8000
-  protocol    = "TCP"
+  protocol    = "HTTP"
   vpc_id      = var.vpc_id
   target_type = "ip"
   health_check {
-    protocol = "TCP"
+    protocol = "HTTP"
+    path     = "/api/v1/healthcheck"
     port     = "8000"
   }
 }
 
-resource "aws_lb_listener" "ecs" {
-  load_balancer_arn = aws_lb.ecs_nlb.arn
-  port              = 80
-  protocol          = "TCP"
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.ecs_alb.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.acm_certificate_arn
+
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.ecs.arn
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.ecs_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
 
@@ -121,7 +174,7 @@ resource "aws_ecs_task_definition" "app" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.ecs.name
-          awslogs-region        = "eu-central-1"
+          awslogs-region        = var.region
           awslogs-stream-prefix = "ecs"
         }
       }
@@ -131,28 +184,6 @@ resource "aws_ecs_task_definition" "app" {
 
 data "aws_vpc" "selected" {
   id = var.vpc_id
-}
-
-resource "aws_security_group" "ecs_service" {
-  name_prefix = "${var.service_name}-sg-"
-  description = "Allow inbound traffic to ECS service from NLB"
-  vpc_id      = var.vpc_id
-  lifecycle {
-    create_before_destroy = true
-  }
-  ingress {
-    from_port   = 8000
-    to_port     = 8000
-    protocol    = "tcp"
-    cidr_blocks = [data.aws_vpc.selected.cidr_block]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 resource "aws_ecs_service" "app" {
@@ -171,10 +202,10 @@ resource "aws_ecs_service" "app" {
     container_name   = var.service_name
     container_port   = 8000
   }
-  depends_on = [aws_lb_listener.ecs]
+  depends_on = [aws_lb_listener.https]
 }
 
-output "nlb_dns_name" {
-  value       = aws_lb.ecs_nlb.dns_name
-  description = "The DNS name of the Network Load Balancer for the ECS service."
+output "alb_dns_name" {
+  value       = aws_lb.ecs_alb.dns_name
+  description = "The DNS name of the Application Load Balancer for the ECS service."
 }


### PR DESCRIPTION
Switch from NLB (Network Load Balancer) to ALB (Application Load Balancer) to support Layer 7 traffic (HTTPS), as only ALB supports features like HTTPS termination, host/path-based routing, and integration with ACM certificates.

See: https://mediamind-service-alb-1972183460.eu-central-1.elb.amazonaws.com