### PR TITLE
Update RDS config with backup and deletion settings

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -3,15 +3,20 @@ variable "db_username" { type = string }
 variable "db_password" { type = string }
 
 resource "aws_db_instance" "postgres" {
-  allocated_storage   = 20
-  engine              = "postgres"
-  engine_version      = "15"
-  instance_class      = "db.t3.micro"
-  db_name             = var.db_name
-  username            = var.db_username
-  password            = var.db_password
-  skip_final_snapshot = true
-  publicly_accessible = true
+  allocated_storage         = 20
+  engine                    = "postgres"
+  engine_version            = "15"
+  instance_class            = "db.t3.micro"
+  db_name                   = var.db_name
+  username                  = var.db_username
+  password                  = var.db_password
+  publicly_accessible       = true
+  backup_retention_period   = 7
+  backup_window             = "03:00-04:00"
+  deletion_protection       = true
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.db_name}-final-snapshot"
+  delete_automated_backups  = false
 }
 
 output "endpoint" {


### PR DESCRIPTION
- Enables automated backups (created between 03:00-04:00, 7 days retention). 
- Enables deletion protection and requires a final snapshot on deletion.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html