### PR TITLE
fix: sentry loading

### DIFF
--- a/frontend/app/pages/error/error.tsx
+++ b/frontend/app/pages/error/error.tsx
@@ -42,7 +42,7 @@ const defaultMessages: Record<string, { title: string; message: string }> = {
       "You are not assigned to an organization. You need to be part of an organization to access Mediamind. Please contact your admin.",
   },
   fallback: {
-    title: "Oohps!",
+    title: "Ohps!",
     message: "Something went wrong! Please contact your admin.",
   },
 };

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -109,7 +109,7 @@ const OutletWrapper = () => {
 
 export default function App({ loaderData }: Route.ComponentProps) {
   useEffect(() => {
-    if (!window.__sentryInitialized) {
+    if (window.__sentryInitialized) {
       return;
     }
     // see https://docs.sentry.io/platforms/javascript/guides/react-router/data-management/data-collected/ for more info

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -23,6 +23,12 @@ import {
 import { Toaster } from "~/components/ui/sonner";
 import { Loader2 } from "lucide-react";
 
+declare global {
+  interface Window {
+    __sentryInitialized?: boolean;
+  }
+}
+
 export async function loader(args: Route.LoaderArgs) {
   return rootAuthLoader(args);
 }
@@ -103,6 +109,9 @@ const OutletWrapper = () => {
 
 export default function App({ loaderData }: Route.ComponentProps) {
   useEffect(() => {
+    if (!window.__sentryInitialized) {
+      return;
+    }
     // see https://docs.sentry.io/platforms/javascript/guides/react-router/data-management/data-collected/ for more info
     Sentry.init({
       dsn: "https://852023ec5d9fe86c64eed907e04346e4@o4509334816489472.ingest.de.sentry.io/4509334885564496",
@@ -124,6 +133,7 @@ export default function App({ loaderData }: Route.ComponentProps) {
       replaysOnErrorSampleRate: 1.0,
       environment: import.meta.env.MODE,
     });
+    window.__sentryInitialized = true;
   }, []);
 
   return (


### PR DESCRIPTION
- @LeonardoZambranoL I think a reroute to the error 404 route is not really necessary, as this is pretty normal for client-side error boundaries.
- The second error on rerouting to "/" was because the remounting of the app after the error boundary. That triggered reloading sentry. Should be fixed
closes #218 