### PR TITLE
chore: use light theme as default

### DIFF
--- a/frontend/app/components/ui/sonner.tsx
+++ b/frontend/app/components/ui/sonner.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps } from "react";
 type ToasterProps = ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const { theme = "light" } = useTheme();
 
   return (
     <Sonner


### PR DESCRIPTION
closes #200 

we dont have themes, thus the hook defaulted to system (which is dark for many people :)) even though rest was light

-> use light as default