### PR TITLE
Set correct env variable reference in Sentry initialization

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,7 +18,7 @@ class AppCreator:
                 dsn=configs.SENTRY_DSN,
                 send_default_pii=True,
                 traces_sample_rate=1.0,
-                environment=configs.ENV,
+                environment=configs.ENVIRONMENT,
             )
 
         logger.info("Starting FastAPI app initialization.")


### PR DESCRIPTION
Set correct env variable reference in Sentry initialization to fix issues with deploying the backend service with `ENVIRONMENT=production`.