### PR TITLE
Fix sync user API call

### DIFF
--- a/frontend/app/hooks/use-authorization.tsx
+++ b/frontend/app/hooks/use-authorization.tsx
@@ -61,7 +61,7 @@ export const AuthorizationContextProvider = ({
   useEffect(() => {
     if (isLoaded && isSignedIn) {
       const sync = async () => {
-        const { data: returnedUser } = await client.POST("/api/v1/users/sync");
+        const { data: returnedUser } = await client.GET("/api/v1/users/sync");
         setMediamindUser(returnedUser);
       };
       sync();


### PR DESCRIPTION
Fix frontend to use the correct method when calling the `/users/sync` endpoint after #237 changed the endpoint.

This should resolve the current problems when loading the dashboard.