### PR TITLE
Fix: regenerated lost alembic files

### DIFF
--- a/backend/alembic/versions/420ae24651f2_add_default_value_to_null_true_columns.py
+++ b/backend/alembic/versions/420ae24651f2_add_default_value_to_null_true_columns.py
@@ -1,0 +1,42 @@
+"""Add default value to null=true columns
+Revision ID: 420ae24651f2
+Revises: d72932518738
+Create Date: 2025-06-25 19:36:33.800364
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+# revision identifiers, used by Alembic.
+revision: str = "420ae24651f2"
+down_revision: Union[str, None] = "d72932518738"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        "entities",
+        "id",
+        server_default=sa.text("'00000000-0000-0000-0000-000000000000'"),
+    )
+    op.alter_column(
+        "entities", "entity_type", server_default=sa.text("'unknown'")
+    )
+    op.alter_column("entities", "value", server_default=sa.text("'unknown'"))
+    op.alter_column(
+        "entities",
+        "article_id",
+        server_default=sa.text("'00000000-0000-0000-0000-000000000000'"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column("entities", "id", server_default=None)
+    op.alter_column("entities", "entity_type", server_default=None)
+    op.alter_column("entities", "value", server_default=None)
+    op.alter_column("entities", "article_id", server_default=None)

--- a/backend/alembic/versions/d50b1d179e6e_merge_heads.py
+++ b/backend/alembic/versions/d50b1d179e6e_merge_heads.py
@@ -1,0 +1,26 @@
+"""Merge heads
+Revision ID: d50b1d179e6e
+Revises: 3d99da666f3e, 420ae24651f2
+Create Date: 2025-06-25 20:10:14.779011
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+# revision identifiers, used by Alembic.
+revision: str = "d50b1d179e6e"
+down_revision: Union[str, None] = ("3d99da666f3e", "420ae24651f2")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
Those two alembic versions are lost but we somehow still need need them: 
`https://github.com/jst-seminar-rostlab-tum/eutop-mediamind/pull/289/files/4c71eb74f3c8a58194aa70fa0174dc71005f973a..e5d8d3b49481787c05c3c7aa3b298cbe12cf0213#diff-3c1053ff48564b4336bdd4eaf98726789526fd43c0b90f4f43968d88efae06b0`

`https://github.com/jst-seminar-rostlab-tum/eutop-mediamind/pull/289/files/4c71eb74f3c8a58194aa70fa0174dc71005f973a..e5d8d3b49481787c05c3c7aa3b298cbe12cf0213#diff-d2c7d8bff741c74014208f7110fb91c889403fd6c5dbc6001bbf49497667fcf9`


