### PR TITLE
Fix error handling for SUBSCRIPTION_ACCOUNTS JSON parsing

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -153,9 +153,7 @@ class Configs(BaseSettings):
             try:
                 return json.loads(v)
             except json.JSONDecodeError as e:
-                raise ValueError(
-                    f"Invalid JSON for SUBSCRIPTION_ACCOUNTS: {e}"
-                )
+                warnings.warn(f"Failed to parse SUBSCRIPTION_ACCOUNTS: {e}. ")
         return v
 
     @model_validator(mode="after")


### PR DESCRIPTION
Log error instead of throwing it to avoid issues with deployments:

![image](https://github.com/user-attachments/assets/28481464-0a9a-4b50-b960-95e711abbec9)
