### PR TITLE
Retouch Crawler Stats

### DIFF
--- a/apps/frontend/app/custom-components/admin-settings/data-table.tsx
+++ b/apps/frontend/app/custom-components/admin-settings/data-table.tsx
@@ -8,7 +8,7 @@ import {
   type SortingState,
   getSortedRowModel,
 } from "@tanstack/react-table";
-import { ArrowDownUp, Plus, SortAsc, SortDesc } from "lucide-react";
+import { ArrowDownUp, Plus, Search, SortAsc, SortDesc } from "lucide-react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "~/components/ui/button";
@@ -63,20 +63,26 @@ export function DataTable<TData, TValue>({
 
   return (
     <>
-      <div className="flex items-center py-4">
-        <Input
-          placeholder={t("search")}
-          value={
-            (table
-              .getColumn(searchField as string)
-              ?.getFilterValue() as string) ?? ""
-          }
-          onChange={(event) => {
-            const value = event.target.value;
-            table.getColumn(searchField as string)?.setFilterValue(value);
-            onSearchChange?.(value); // send value to parent
-          }}
-        />
+      <div className="flex items-center w-full">
+        <div className="relative w-full flex items-center">
+          <Input
+            placeholder={t("search")}
+            value={
+              (table
+                .getColumn(searchField as string)
+                ?.getFilterValue() as string) ?? ""
+            }
+            onChange={(event) => {
+              const value = event.target.value;
+              table.getColumn(searchField as string)?.setFilterValue(value);
+              onSearchChange?.(value); // send value to parent
+            }}
+          />
+          <Search
+            size={20}
+            className="absolute right-3 text-muted-foreground"
+          />
+        </div>
         {onAdd && (
           <Button variant={"outline"} className="ml-4" onClick={onAdd}>
             {t("Add")}
@@ -85,7 +91,7 @@ export function DataTable<TData, TValue>({
         )}
       </div>
       <Table>
-        <TableHeader>
+        <TableHeader className="bg-blue-100">
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => {
@@ -155,7 +161,7 @@ export function DataTable<TData, TValue>({
           ) : (
             <TableRow>
               <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
+                {t("admin.no_results")}
               </TableCell>
             </TableRow>
           )}

--- a/apps/frontend/app/pages/crawler-stats/crawler-stats.tsx
+++ b/apps/frontend/app/pages/crawler-stats/crawler-stats.tsx
@@ -18,6 +18,7 @@ import { type ColumnDef } from "@tanstack/react-table";
 import type { Stat } from "types/model";
 import { DataTable } from "~/custom-components/admin-settings/data-table";
 import { format } from "date-fns";
+import { Card } from "~/components/ui/card";
 
 export const CrawlerStatsPage = () => {
   const { t } = useTranslation();
@@ -103,19 +104,23 @@ export const CrawlerStatsPage = () => {
       </Breadcrumb>
       <Text hierachy={2}>{t("crawler_stats.title")}</Text>
 
-      <DatePicker
-        startDate={startDate}
-        endDate={endDate}
-        setStartDate={setStartDate}
-        setEndDate={setEndDate}
-      />
-      <div className="space-y-6 p-6">
-        <DataTable
-          columns={columns}
-          data={data?.stats ?? []}
-          searchField="subscription_name"
-        />
-      </div>
+      <Card className="gap-0">
+        <div className="px-6">
+          <DatePicker
+            startDate={startDate}
+            endDate={endDate}
+            setStartDate={setStartDate}
+            setEndDate={setEndDate}
+          />
+        </div>
+        <div className="space-y-4 p-6 pt-4">
+          <DataTable
+            columns={columns}
+            data={data?.stats ?? []}
+            searchField="subscription_name"
+          />
+        </div>
+      </Card>
     </Layout>
   );
 };


### PR DESCRIPTION
- Adjusted Table und UI to match Admin Settings Layout

<img width="1357" height="1256" alt="image" src="https://github.com/user-attachments/assets/aa918cc1-2ccc-46e0-a1bf-aec82c3fbe66" />

Idea: Do we want to add a panel on the top with for example: Total attempted, then ratio of positives ratio of negatives, etc. as a chart with colors maybe?