### PR TITLE
bug/improved search with search term

### DIFF
--- a/apps/backend/app/services/search_profiles_service.py
+++ b/apps/backend/app/services/search_profiles_service.py
@@ -331,10 +331,12 @@ class SearchProfileService:
             min_match = len(search_words)
 
             def field_match(field):
-                combined_words = set()
-                for field in fields:
-                    combined_words.update(split_words(field))
-                return sum(w in combined_words for w in search_words)
+                combined_text = " ".join(fields).lower()
+                combined_words = set(split_words(combined_text))
+                return sum(
+                    w in combined_words or w in combined_text
+                    for w in search_words
+                )
 
             all_matches = await MatchRepository.get_matches_by_search_profile(
                 search_profile_id,

--- a/apps/backend/app/services/search_profiles_service.py
+++ b/apps/backend/app/services/search_profiles_service.py
@@ -328,7 +328,7 @@ class SearchProfileService:
                 return re.findall(r"[\wäöüßÄÖÜ]+", text.lower())
 
             search_words = split_words(request.searchTerm)
-            min_match = max(1, len(search_words) // 2)
+            min_match = max(1, int(len(search_words) * 0.75))
 
             def field_match(field):
                 field_words = split_words(field)
@@ -348,8 +348,6 @@ class SearchProfileService:
                     m.article.title_en or "",
                     m.article.summary_de or "",
                     m.article.summary_en or "",
-                    m.article.content_de or "",
-                    m.article.content_en or "",
                 ]
                 found = False
                 for field in fields:

--- a/apps/backend/app/services/search_profiles_service.py
+++ b/apps/backend/app/services/search_profiles_service.py
@@ -328,13 +328,13 @@ class SearchProfileService:
                 return re.findall(r"[\wäöüßÄÖÜ]+", text.lower())
 
             search_words = split_words(request.searchTerm)
-            min_match = max(1, int(len(search_words) * 0.75))
+            min_match = len(search_words)
 
             def field_match(field):
-                field_words = split_words(field)
-                return sum(
-                    w in field_words or w in field for w in search_words
-                )
+                combined_words = set()
+                for field in fields:
+                    combined_words.update(split_words(field))
+                return sum(w in combined_words for w in search_words)
 
             all_matches = await MatchRepository.get_matches_by_search_profile(
                 search_profile_id,


### PR DESCRIPTION
solves https://github.com/jst-seminar-rostlab-tum/eutop-mediamind/issues/621
The earlier logic was to call retrieve_by_similarity. It turns out no articles were returned even set the threshold to 0. When calling endpoints of Qdrant libriary directly, it will return some results, but the results are barely accuare, for example if you search for electric vihecles, it shows articles about NVIDIA company values. I assume it's the vector db stores all summaries which every word will be taken into consideration, thus the valuable results might be discarded(attention is all you need:-)).

New logic is keyword search in summaries & titles in both languges, return articles in which every keyword of the search term matches. It supports also sentences in en/de.
The reason I excluded search in article content is because contents are too long to contain everything to make the results not accurate enough.

It's not perfect, after testing it's for now the optimal solution, and I believe it's still better than vector search which returns unrelevant articles in higher chance. 
<img width="1228" height="702" alt="image" src="https://github.com/user-attachments/assets/2e1c6d0f-095a-4313-943a-59f02a62e935" />
It also supports prefix/infix search.

