### PR TITLE
Set timeout for Qdrant client initialization

### DIFF
--- a/apps/backend/app/core/db.py
+++ b/apps/backend/app/core/db.py
@@ -69,7 +69,7 @@ def get_qdrant_connection() -> QdrantClient:
         client = QdrantClient(
             url=configs.QDRANT_URL,
             api_key=configs.QDRANT_API_KEY,
-            timeout=30 # seconds
+            timeout=30,  # seconds
         )
         return client
 

--- a/apps/backend/app/core/db.py
+++ b/apps/backend/app/core/db.py
@@ -69,6 +69,7 @@ def get_qdrant_connection() -> QdrantClient:
         client = QdrantClient(
             url=configs.QDRANT_URL,
             api_key=configs.QDRANT_API_KEY,
+            timeout=30 # seconds
         )
         return client
 


### PR DESCRIPTION
Increases timeout from 5s to 30s for REST calls to Qdrant.